### PR TITLE
Implement regex in all commands 

### DIFF
--- a/src/commands/ICommandHandler.ts
+++ b/src/commands/ICommandHandler.ts
@@ -4,5 +4,6 @@ export interface ICommandHandler {
   execute: (message: Message) => Promise<void>;
   test: (content: string) => boolean;
   name: string;
+  regex?: RegExp;
   description?: string;
 }

--- a/src/commands/admin/set-admin-role/set-admin-role.handler.spec.ts
+++ b/src/commands/admin/set-admin-role/set-admin-role.handler.spec.ts
@@ -1,4 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import * as sinon from 'sinon';
+import { Message } from 'discord.js';
 
 import { SetAdminRoleHandler } from './set-admin-role.handler';
 import {
@@ -8,19 +10,28 @@ import {
 import { ServerModule } from '../../../server/server.module';
 import { ConfigModule } from '../../../config/config.module';
 import { ConfigService } from '../../../config/config.service';
+import { ServerService } from '../../../server/server.service';
 
 describe(`SetAdminRoleHandler`, () => {
+  const sandbox = sinon.createSandbox();
   let setAdminRoleHandler: SetAdminRoleHandler;
   let configService: ConfigService;
+  let testModule: TestingModule;
 
   beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    testModule = await Test.createTestingModule({
       imports: [ServerModule, ConfigModule, rootMongooseTestModule()],
       providers: [SetAdminRoleHandler],
     }).compile();
 
-    setAdminRoleHandler = module.get<SetAdminRoleHandler>(SetAdminRoleHandler);
+    setAdminRoleHandler = testModule.get<SetAdminRoleHandler>(
+      SetAdminRoleHandler,
+    );
     configService = new ConfigService();
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
   });
 
   afterAll(async () => {
@@ -47,5 +58,31 @@ describe(`SetAdminRoleHandler`, () => {
         `asdasd ${configService.adminPrefix} set admin role <@&3114124>`,
       ),
     ).toBeFalsy();
+  });
+
+  it('call the serverservice and reply an embed', async () => {
+    const CHAN_ID = '123123123';
+    const message = {
+      content: `${configService.adminPrefix} set admin role <@&${CHAN_ID}>`,
+      channel: {
+        send: sinon.stub(),
+      },
+      guild: {
+        id: 'FAKE',
+      },
+      author: {
+        id: '123123',
+      },
+    } as any;
+
+    const serverService = testModule.get<ServerService>(ServerService);
+    const setAdminRoleStub = sandbox.stub(serverService, 'setAdminRole');
+
+    await setAdminRoleHandler.execute(message);
+    expect(setAdminRoleStub.getCall(0).args[2]).toEqual(CHAN_ID);
+    expect(message.channel.send.callCount).toEqual(1);
+
+    const replyedEmbed = message.channel.send.getCall(0).args[0];
+    expect(replyedEmbed.description).toMatch(new RegExp(CHAN_ID));
   });
 });

--- a/src/commands/admin/set-admin-role/set-admin-role.handler.ts
+++ b/src/commands/admin/set-admin-role/set-admin-role.handler.ts
@@ -14,21 +14,18 @@ export class SetAdminRoleHandler implements ICommandHandler {
   name = `${this.configService.adminPrefix} set admin role <@role>`;
   description =
     'set role with admin permissions on the bot for the current server';
+  regex = new RegExp(
+    `^${this.configService.adminPrefix} SET ADMIN role <@&(.+)>`,
+    'i',
+  );
 
   test(content: string): boolean {
-    return new RegExp(
-      `^${this.configService.adminPrefix} set admin role <@&.+>`,
-      'i',
-    ).test(content);
+    return this.regex.test(content);
   }
 
   async execute(message: Message): Promise<void> {
-    const [msg, roleId] = message.content.match(
-      new RegExp(
-        `^${this.configService.adminPrefix} SET ADMIN role <@&(.+)>`,
-        'i',
-      ),
-    );
+    const [msg, roleId] = message.content.match(this.regex);
+
     Logger.debug(`captured role id ${roleId}`, 'setAdminRoleHandler');
     try {
       await this.serverService.setAdminRole(

--- a/src/commands/admin/set-prefix/set-prefix.handler.spec.ts
+++ b/src/commands/admin/set-prefix/set-prefix.handler.spec.ts
@@ -1,4 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import * as sinon from 'sinon';
+
 import {
   closeInMongodConnection,
   rootMongooseTestModule,
@@ -6,24 +8,61 @@ import {
 import { ServerModule } from '../../../server/server.module';
 import { SetPrefixHandler } from './set-prefix.handler';
 import { ConfigModule } from '../../../config/config.module';
+import { ConfigService } from '../../../config/config.service';
+import { ServerService } from '../../../server/server.service';
 
 describe('SetPrefixService', () => {
+  const sandbox = sinon.createSandbox();
+
   let setPrefixHandler: SetPrefixHandler;
+  let testingModule: TestingModule;
 
   beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    testingModule = await Test.createTestingModule({
       imports: [rootMongooseTestModule(), ServerModule, ConfigModule],
       providers: [SetPrefixHandler],
     }).compile();
 
-    setPrefixHandler = module.get<SetPrefixHandler>(SetPrefixHandler);
+    setPrefixHandler = testingModule.get<SetPrefixHandler>(SetPrefixHandler);
   });
 
-  afterEach(async () => {
+  afterAll(async () => {
     await closeInMongodConnection();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
   });
 
   it('should be defined', () => {
     expect(setPrefixHandler).toBeDefined();
+  });
+
+  it('should call the server service and send an embed', async () => {
+    const config = testingModule.get<ConfigService>(ConfigService);
+    const message = {
+      content: `${config.adminPrefix} set prefix coco`,
+      author: {
+        id: '123123',
+      },
+      guild: {
+        id: '345345',
+      },
+      channel: {
+        send: sinon.stub(),
+      },
+    } as any;
+
+    const serverService = testingModule.get<ServerService>(ServerService);
+    sandbox.stub(serverService, 'hasAdminRoleGuard');
+    const setServerPrefixStub = sandbox
+      .stub(serverService, 'setServerPrefix')
+      .returns(Promise.resolve('coco'));
+
+    await setPrefixHandler.execute(message);
+    expect(setServerPrefixStub.getCall(0).args[1]).toEqual('coco');
+
+    const replyedEmbed = message.channel.send.getCall(0).args[0];
+    expect(replyedEmbed.description).toMatch(/coco/);
   });
 });

--- a/src/commands/admin/set-prefix/set-prefix.handler.ts
+++ b/src/commands/admin/set-prefix/set-prefix.handler.ts
@@ -15,13 +15,10 @@ export class SetPrefixHandler implements ICommandHandler {
   name = `${this.configService.adminPrefix} set prefix <prefix>`;
   description =
     'allow server admin to define a custom prefix for user commands';
+  regex = new RegExp(`^${this.configService.adminPrefix} set prefix (.*)`, 'i');
 
   test(content: string): boolean {
-    const regexp = new RegExp(
-      `^${this.configService.adminPrefix} set prefix .*`,
-      'i',
-    );
-    return regexp.test(content);
+    return this.regex.test(content);
   }
 
   async execute(message: Message): Promise<void> {
@@ -29,9 +26,7 @@ export class SetPrefixHandler implements ICommandHandler {
       message.guild,
       message.author.id,
     );
-    const [_, prefix] = message.content.match(
-      new RegExp(`^${this.configService.adminPrefix} set prefix (.*)`, 'i'),
-    );
+    const [_, prefix] = message.content.match(this.regex);
 
     const savedPrefix = await this.serverService.setServerPrefix(
       message.guild.id,

--- a/src/commands/commands.service.ts
+++ b/src/commands/commands.service.ts
@@ -51,10 +51,15 @@ export class CommandsService {
   }
   register(client: Client) {
     for (const command of this.commandHandlers) {
-      Logger.log(`${command.name} registered`, 'CommandExplorer');
+      Logger.log(
+        `${command.name} registered => ${
+          command.regex ?? command.description ?? '?'
+        }`,
+        'CommandExplorer',
+      );
     }
 
-    client.on('message', async message => {
+    client.on('message', async (message) => {
       try {
         await this.messageHandler(message);
       } catch (error) {


### PR DESCRIPTION
Update the interface `ICommandHandler` to support the regex property

Set as optional for now. When all the default commands will be migrated it will be switched to mandatory.

**sample**
set admin role
set prefix

close #55 